### PR TITLE
build: introduce Gradle Toolchain Resolver Plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = 'harinoki'


### PR DESCRIPTION
Introduce Toolchain Resolver Plugin for enabling Java toolchain auto-provisioning feature.