### PR TITLE
Replace SLF4J binding from slf4j-simple to jetty-slf4j-impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,11 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.19.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
-    // TODO: logger implementation
-    implementation 'org.slf4j:slf4j-simple:1.7.36'
-
+    implementation 'org.eclipse.jetty:jetty-slf4j-impl:11.0.24'
     testFixturesApi 'org.eclipse.jetty:jetty-webapp:11.0.24'
     testFixturesImplementation 'org.eclipse.jetty:jetty-security:11.0.24'
     testFixturesImplementation 'org.eclipse.jetty:jetty-util:11.0.24'
     testFixturesImplementation 'org.eclipse.jetty:jetty-server:11.0.24'
-
-    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
     testImplementation platform('org.junit:junit-bom:5.10.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/src/test/resources/jetty-logging.properties
+++ b/src/test/resources/jetty-logging.properties
@@ -1,0 +1,14 @@
+## Set logging levels from: ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF
+#org.eclipse.jetty.LEVEL=INFO
+org.eclipse.jetty.LEVEL=ERROR
+## Configure a level for an arbitrary logger tree
+#com.example.LEVEL=INFO
+## Configure a level for specific logger
+#com.example.MyComponent.LEVEL=INFO
+## Configure JMX Context Name
+# org.eclipse.jetty.logging.jmx.context=JettyServer
+## Hide stacks traces in an arbitrary logger tree
+#com.example.STACKS=false
+
+## Configure Harinoki
+com.tsurugidb.harinoki.LEVEL=TRACE


### PR DESCRIPTION
This Pull Request replaces SLF4J logger implementation from `slf4j-simple` to `jetty-slf4j-impl` for aligning runtime logging with Jetty server.